### PR TITLE
Using parameter group name for redis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_elasticache_replication_group" "default" {
   replication_group_description = module.labels.id
   engine_version                = var.engine_version
   port                          = var.port
-  parameter_group_name          = "default.redis5.0"
+  parameter_group_name          = var.parameter_group_name
   node_type                     = var.node_type
   automatic_failover_enabled    = var.automatic_failover_enabled
   subnet_group_name             = join("", aws_elasticache_subnet_group.default.*.name)
@@ -68,7 +68,7 @@ resource "aws_elasticache_replication_group" "cluster" {
   replication_group_description = module.labels.id
   engine_version                = var.engine_version
   port                          = var.port
-  parameter_group_name          = "default.redis5.0.cluster.on"
+  parameter_group_name          = var.parameter_group_name
   node_type                     = var.node_type
   automatic_failover_enabled    = var.automatic_failover_enabled
   subnet_group_name             = join("", aws_elasticache_subnet_group.default.*.name)


### PR DESCRIPTION
Propagating the parameter_group_name variable through to the redis resources. This will allow custom parameter groups to be used if other parameters want to be changed, such as maxmemory policy

Would also be great if you could backport this change to 0.12.x 

thank you!
