### PR TITLE
added arn outputs for redis/memcache

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,17 @@ output "redis_endpoint" {
   description = "Redis endpoint address."
 }
 
+output "redis_arn" {
+  value       = length(aws_elasticache_replication_group.cluster) > 0 ? aws_elasticache_replication_group.cluster[0].arn : length(aws_elasticache_replication_group.default) > 0 ? aws_elasticache_replication_group.default[0].arn : ""
+  description = "Redis arn"
+}
+
 output "memcached_endpoint" {
   value       = var.cluster_enabled ? join("", aws_elasticache_cluster.default.*.configuration_endpoint) : ""
   description = "Memcached endpoint address."
+}
+
+output "memcached_arn" {
+  value       = length(aws_elasticache_cluster.default) > 0 ? aws_elasticache_cluster.default[0].arn : ""
+  description = "Memcached arn"
 }


### PR DESCRIPTION
## what
* Adds ARN outputs to the redis standalone/cluster and memcache cluster

## why
* Helpful for working with other TF code / projects that need the ARN to reference redis/memcache

## references
* Fix for [this reddit post](https://www.reddit.com/r/Terraform/comments/zaimqo/how_to_get_arn_as_output/)
