### PR TITLE
feat: enable multi-az for redis (non-clustered)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "aws_elasticache_replication_group" "default" {
   snapshot_retention_limit      = var.snapshot_retention_limit
   apply_immediately             = var.apply_immediately
   availability_zones            = slice(var.availability_zones, 0, var.number_cache_clusters)
+  multi_az_enabled              = var.multi_az_enabled
   number_cache_clusters         = var.number_cache_clusters
   auto_minor_version_upgrade    = var.auto_minor_version_upgrade
   maintenance_window            = var.maintenance_window

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,12 @@ variable "availability_zones" {
   description = "A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important."
 }
 
+variable "multi_az_enabled" {
+  type        = bool
+  default     = false
+  description = "Specify if multi-AZ should be enabled for this Redis instance."
+}
+
 variable "number_cache_clusters" {
   type        = string
   default     = ""


### PR DESCRIPTION
## what
* Adds the `multi_az_enabled` variable to unclustered Elasticache Redis. I've tested this on an Elasticache cluster at my company, and this worked as expected.

## why
* While the documentation says that this feature gets enabled when `automatic_failover_enabled` is `true`, this has not been true in practice. Therefore, adding a new flag to allow this to be set up independently.

