### PR TITLE
conditional check on outputing auth_token

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -61,7 +61,7 @@ output "Memcached_ssm_name" {
 }
 
 output "auth_token" {
-  value       = random_password.auth_token[0].result
+  value       = var.auth_token_enable ? random_password.auth_token[0].result : ""
   sensitive   = true
   description = "Auth token generated value"
 }


### PR DESCRIPTION
## what
* Outputting the auth_token parameters is now conditional on if the auth_token_enable parameter was specified as true

## why
* Without this conditional check, if a user specified encryption in transit as false, the template fails to deploy on this error

## references

