### PR TITLE
fix: auth_token output when transit_encryption_enabled set to false

### DIFF
--- a/.github/workflows/auto_assignee.yml
+++ b/.github/workflows/auto_assignee.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   assignee:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@1.0.6
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@1.0.9
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
     with:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,12 @@
+---
+name: Auto merge
+on:
+  pull_request:
+jobs:
+  auto-merge:
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@1.0.9
+    secrets:
+      GITHUB: ${{ secrets.GITHUB }}
+    with:
+      tfcheck: 'redis-cluster / Check code format'
+...

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   changelog:
-    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@1.0.6
+    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@1.0.9
     secrets: inherit
     with:
       branch: 'master'

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 jobs:
-  readme:
+  readme-create:
     name: 'readme-create'
     runs-on: ubuntu-latest
     steps:
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: 'Set up Python 3.7'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -24,7 +24,6 @@ jobs:
           github_token: '${{ secrets.GITHUB }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: 'pre-commit check errors'
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,14 +6,14 @@ on:
   workflow_dispatch:
 jobs:
   memcached:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.6
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.9
     with:
       working_directory: './_example/memcached/'
   redis:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.6
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.9
     with:
       working_directory: './_example/redis/'
   redis-cluster:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.6
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.0.9
     with:
       working_directory: './_example/redis-cluster/'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -6,6 +6,6 @@ on:
   workflow_dispatch:
 jobs:
   tflint:
-    uses: clouddrove/test-tfsec/.github/workflows/tflint.yaml@1.0.6
+    uses: clouddrove/test-tfsec/.github/workflows/tf-lint.yml@1.0.9
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  tflint:
-    uses: clouddrove/test-tfsec/.github/workflows/tf-lint.yml@1.0.9
+  tf-lint:
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@1.0.10
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,7 +61,7 @@ output "Memcached_ssm_name" {
 }
 
 output "auth_token" {
-  value       = random_password.auth_token[0].result
+  value       = var.auth_token_enable ? random_password.auth_token[0].result : ""
   sensitive   = true
   description = "Auth token generated value"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,7 +184,7 @@ variable "auth_token_enable" {
 variable "auth_token" {
   type        = string
   default     = null
-  description = "The password used to access a password protected server. Can be specified only if transit_encryption_enabled = true."
+  description = "The password used to access a password protected server. Can be specified only if transit_encryption_enabled = true. Find auto generated auth_token in terraform.tfstate or in AWS SSM Parameter Store."
 }
 
 variable "cluster_replication_enabled" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,15 +1,15 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.2"
+  required_version = ">= 1.6.6"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.22.0"
+      version = ">= 5.31.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.5.1"
+      version = ">= 3.6.0"
     }
   }
 }


### PR DESCRIPTION
## what
- `auth_token` output when `transit_encryption_enabled` set to false

## why
- If `transit_encryption_enabled` is set to false then the `auth_token` output throws below error.
```bash
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid index
│ 
│   on .terraform/modules/redis/outputs.tf line 64, in output "auth_token":
│   64:   value       = random_password.auth_token[0].result
│     ├────────────────
│     │ random_password.auth_token is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```