### PR TITLE
fix: add tags variable as alias for extra_tags (cross-module consistency)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "labels" {
   environment = var.environment
   managedby   = var.managedby
   label_order = var.label_order
-  extra_tags  = var.extra_tags
+  extra_tags  = merge(var.extra_tags, var.tags)
 }
 
 ##----------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "extra_tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)."
 }
 
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to merge with extra_tags. Alias for extra_tags for consistency with other CloudDrove modules (aurora, waf, vpc) that use 'tags' as the input variable name."
+}
+
 variable "managedby" {
   type        = string
   default     = "anmol@clouddrove.com"


### PR DESCRIPTION
## Problem

This module uses `extra_tags` as the input variable for consumer tag injection. Other CloudDrove modules (`aurora`, `waf`, `vpc`, `subnet`) use `tags` for the same purpose. Consumers calling multiple CloudDrove modules uniformly cannot use the same variable name pattern:

```hcl
# Works for aurora, waf, vpc:
tags = module.labels.tags

# elasticache silently ignores 'tags', requires 'extra_tags':
extra_tags = module.labels.tags
```

When a consumer passes `tags = ...` to this module, Terraform throws:
```
Error: Unsupported argument - An argument named "tags" is not expected here.
```

Reported in #102.

## Fix

Adds a `tags` variable (defaults to `{}`) and merges it with `extra_tags` in the labels module call:

```hcl
extra_tags = merge(var.extra_tags, var.tags)
```

- **Non-breaking**: existing consumers using `extra_tags` are unaffected
- `tags` and `extra_tags` can be used independently or together; `tags` takes precedence on key collisions
- Makes this module consistent with `clouddrove/aurora/aws`, `clouddrove/waf/aws`, `clouddrove/vpc/aws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)